### PR TITLE
spi_cfg

### DIFF
--- a/SPI/include/spi.h
+++ b/SPI/include/spi.h
@@ -1,0 +1,60 @@
+/**
+ * @file spi.h
+ * @author Jose Luis Figueroa 
+ * @brief The interface definition for the spi. This is the header file for 
+ * the definition of the interface for a Serial Peripheral Serial (SPI) on 
+ * a standard microcontroller.
+ * @version 1.0
+ * @date 2023-07-14
+ * 
+ * @copyright Copyright (c) 2023 Jose Luis Figueroa. All rights reserved.
+ * 
+ */
+#ifndef SPI_H_
+#define SPI_H_
+
+/*****************************************************************************
+* Includes
+*****************************************************************************/
+#include <stdint.h>
+#include <stdio.h>
+#include "spi_cfg.h"    /*For dio configuration*/
+#include "stm32f4xx.h"  /** TODO: Microcontroller family header*/ 
+
+/*****************************************************************************
+* Preprocessor Constants
+*****************************************************************************/
+
+/*****************************************************************************
+* Configuration Constants
+*****************************************************************************/
+
+/*****************************************************************************
+* Macros
+*****************************************************************************/
+
+/*****************************************************************************
+* Typedefs
+*****************************************************************************/
+
+/*****************************************************************************
+* Variables
+*****************************************************************************/
+
+/*****************************************************************************
+* Function Prototypes
+*****************************************************************************/
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+void SPI_Init(SpiConfig_t const * const Config);
+void SPI_Transfer(uint16_t *data, uint16_t size);
+void SPI_RegisterWrite(uint32_t address, TYPE value);
+TYPE SPI_RegisterRead(uint32_t address);
+
+#ifdef __cplusplus
+} // extern C
+#endif
+
+#endif /*SPI_H_*/

--- a/SPI/include/spi_cfg.h
+++ b/SPI/include/spi_cfg.h
@@ -24,13 +24,13 @@
 /** 
  * Defines the number of ports on the processor.
  */
-#define NUMBER_OF_PORTS 4U
+#define SPI_PORTS_NUMBER 4U
 
 /** 
  * Set the value according with the number of Serial Peripheral 
  * interface channels to be used.
 */
-#define NUMBER_DIGITAL_PINS 1
+#define SPI_CHANNELS_NUMBER 1
 
 /**********************************************************************
 * Typedefs

--- a/SPI/include/spi_cfg.h
+++ b/SPI/include/spi_cfg.h
@@ -1,0 +1,144 @@
+/**
+ * @file spi_cfg.h
+ * @author Jose Luis Figueroa 
+ * @brief This module contains interface definitions for the SPI
+ * configuration. This is the header file for the definition of the
+ * interface for retrieving the Serial Peripheral interface
+ * configuration table.
+ * @version 1.0
+ * @date 2023-07-14
+ * 
+ * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * 
+ */
+#ifndef SPI_H_
+#define SPI_H_
+
+/**********************************************************************
+* Includes
+**********************************************************************/
+
+/**********************************************************************
+* Preprocessor Constants
+**********************************************************************/
+/** 
+ * Defines the number of ports on the processor.
+ */
+/** TODO: Populate with the number of PSI ports on the microcontroller*/
+#define NUMBER_OF_PORTS 4U
+
+/** 
+ * Set the value according with the number of digital input/output 
+ * peripheral channel (pins) used.
+*/
+/** TODO: Populate with the number of SPI channels that will be used*/
+#define NUMBER_DIGITAL_PINS 1
+
+/**********************************************************************
+* Typedefs
+**********************************************************************/
+/**
+ * Define the bus mode according to clock polarity and clock phase.
+ */
+typedef enum
+{
+    /** TODO: Populate this list based on available MCU baud rate*/
+    SPI_MODE0,      /**< Mode 0 (CPOL=0 and CPHA=0)*/      
+    SPI_MODE1,      /**< Mode 1 (CPOL=0 and CPHA=1)*/ 
+    SPI_MODE2,      /**< Mode 2 (CPOL=1 and CPHA=0)*/ 
+    SPI_MODE3,      /**< Mode 3 (CPOL=1 and CPHA=1)*/ 
+    SPI_MAX_MODE    /**< Maximum mode */
+}SpiMode_t;
+
+/**
+ * Define the hierarchy of the device. Set the device as slave or 
+ * master.
+ */
+typedef enum
+{
+    /** TODO: Populate this list based on available MCU hierarchy mode*/
+    SPI_SLAVE,          /**< Slave configuration*/
+    SPI_MASTER,         /**< Master configuration*/
+    SPI_MAX_HIERARCHY   /**< Maximum hierarchy*/
+}SpiHierarchy_t;
+
+/**
+ * Define the baud rate control.
+*/
+typedef enum
+{
+    /** TODO: Populate this list based on available MCU baud rate*/
+    SPI_FPCLK2,     /**< Baud rate divided by 2*/
+    SPI_FPCLK4,     /**< Baud rate divided by 4*/
+    SPI_FPCLK8,     /**< Baud rate divided by 8*/
+    SPI_FPCLK16,    /**< Baud rate divided by 16*/
+    SPI_FPCLK32,    /**< Baud rate divided by 32*/
+    SPI_FPCLK128,   /**< Baud rate divided by 128*/
+    SPI_FPCLK256,   /**< Baud rate divided by 256*/
+    SPI_MAX_FPCLK   /**< Maximum baud rate*/
+}SpiBaudRate_t;
+
+/**
+ * Define the frame format. Choose the direction of the data frame 
+ * to be sent.
+ */
+typedef enum
+{
+    /** TODO: Populate this list based on available MCU frame format*/
+    SPI_MSB,    /**< Most significant bit transmitted first*/
+    SPI_LSB,    /**< Less significant bit transmitted first*/
+    SPI_MAX_FF  /**< Maximum frame format*/
+}SpiFrameFormat_t;
+
+/**
+ * Define the type of data transfer.  
+ */
+typedef enum
+{
+    /** TODO: Populate this list based on available MCU type transfer*/
+    SPI_FULL_DUPLEX,    /**< Set full duplex communication*/
+    SPI_RECEIVE_MODE,   /**< Set Receive only communication*/
+    SPI_MAX_DF          /**< Set the maximum data transfer*/
+}SpiTypeTransfer_t;
+
+/**
+ * Define the data frame format. Set bits number of data.
+ */
+typedef enum
+{
+    /** TODO: Populate this list based on available MCU data size*/
+    SPI_8BITS,  /**< 8 bits data is selected for communication*/
+    SPI_16BITS  /**< 16 bits data is selected for communication*/
+}SpiDataSize_t;
+
+/**
+ * Defines the Serial Peripheral Interface configuration table's 
+ * elements that are used by Spi_Init to configure the SPI peripheral.
+ */
+typedef struct
+{
+    /** TODO: Add additional members for the MCU peripheral if needed */
+    SpiMode_t Mode;
+    SpiHierarchy_t Hierarchy;
+    SpiBaudRate_t BaudRate;
+    SpiFrameFormat_t FrameFormat;
+    SpiTypeTransfer_t TypeTransfer;
+    SpiDataSize_t DataSize;
+}SpiConfig_t;
+
+
+/**********************************************************************
+* Function Prototypes
+**********************************************************************/
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+const SpiConfig_t * const SPI_ConfigGet(void);
+
+
+#ifdef __cplusplus
+} //extern "C"
+#endif
+
+#endif  /*SPI_H_*/

--- a/SPI/include/spi_cfg.h
+++ b/SPI/include/spi_cfg.h
@@ -24,14 +24,12 @@
 /** 
  * Defines the number of ports on the processor.
  */
-/** TODO: Populate with the number of PSI ports on the microcontroller*/
 #define NUMBER_OF_PORTS 4U
 
 /** 
- * Set the value according with the number of digital input/output 
- * peripheral channel (pins) used.
+ * Set the value according with the number of Serial Peripheral 
+ * interface channels to be used.
 */
-/** TODO: Populate with the number of SPI channels that will be used*/
 #define NUMBER_DIGITAL_PINS 1
 
 /**********************************************************************
@@ -42,7 +40,6 @@
  */
 typedef enum
 {
-    /** TODO: Populate this list based on available MCU baud rate*/
     SPI_MODE0,      /**< Mode 0 (CPOL=0 and CPHA=0)*/      
     SPI_MODE1,      /**< Mode 1 (CPOL=0 and CPHA=1)*/ 
     SPI_MODE2,      /**< Mode 2 (CPOL=1 and CPHA=0)*/ 
@@ -67,7 +64,6 @@ typedef enum
 */
 typedef enum
 {
-    /** TODO: Populate this list based on available MCU baud rate*/
     SPI_FPCLK2,     /**< Baud rate divided by 2*/
     SPI_FPCLK4,     /**< Baud rate divided by 4*/
     SPI_FPCLK8,     /**< Baud rate divided by 8*/
@@ -84,7 +80,6 @@ typedef enum
  */
 typedef enum
 {
-    /** TODO: Populate this list based on available MCU frame format*/
     SPI_MSB,    /**< Most significant bit transmitted first*/
     SPI_LSB,    /**< Less significant bit transmitted first*/
     SPI_MAX_FF  /**< Maximum frame format*/
@@ -95,7 +90,6 @@ typedef enum
  */
 typedef enum
 {
-    /** TODO: Populate this list based on available MCU type transfer*/
     SPI_FULL_DUPLEX,    /**< Set full duplex communication*/
     SPI_RECEIVE_MODE,   /**< Set Receive only communication*/
     SPI_MAX_DF          /**< Set the maximum data transfer*/
@@ -106,7 +100,6 @@ typedef enum
  */
 typedef enum
 {
-    /** TODO: Populate this list based on available MCU data size*/
     SPI_8BITS,  /**< 8 bits data is selected for communication*/
     SPI_16BITS  /**< 16 bits data is selected for communication*/
 }SpiDataSize_t;
@@ -117,7 +110,6 @@ typedef enum
  */
 typedef struct
 {
-    /** TODO: Add additional members for the MCU peripheral if needed */
     SpiMode_t Mode;
     SpiHierarchy_t Hierarchy;
     SpiBaudRate_t BaudRate;
@@ -135,7 +127,6 @@ extern "C"{
 #endif
 
 const SpiConfig_t * const SPI_ConfigGet(void);
-
 
 #ifdef __cplusplus
 } //extern "C"

--- a/SPI/src/spi.c
+++ b/SPI/src/spi.c
@@ -1,0 +1,192 @@
+/**
+ * @file spi.c
+ * @author Jose Luis Figueroa 
+ * @brief The implementation for the SPI.
+ * @version 1.0
+ * @date 2023-07-14
+ * 
+ * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * 
+ */
+/*****************************************************************************
+* Includes
+*****************************************************************************/
+#include "spi.h"
+
+/*****************************************************************************
+* Module Preprocessor Constants
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Preprocessor Macros
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Typedefs
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Variable Definitions
+*****************************************************************************/
+/** TODO: Populate all the peripheral register with the proper instances*/
+/**
+ * Defines a table of pointers to the peripheral input register on the 
+ * microcontroller.
+*/
+
+
+/*****************************************************************************
+* Function Prototypes
+*****************************************************************************/
+
+/*****************************************************************************
+* Function Definitions
+*****************************************************************************/
+/*****************************************************************************
+ * Function: SPI_init()
+*//**
+*\b Description:
+ * This function is used to initialize the spi based on the configuration  
+ * table defined in spi_cfg module.
+ * 
+ * PRE-CONDITION: Configuration table needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: SPI pins should be configured using GPIO driver.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * 
+ * POST-CONDITION: The peripheral is set up with the configuration settings.
+ * 
+ * @param[in]   Config is a pointer to the configuration table that contains 
+ *               the initialization for the peripheral.
+ * 
+ * @return  void
+ * 
+ * \b Example:
+ * @code
+ *  const SpiConfig_t * const SpiConfig = SPI_configGet();
+ *  SPI_Init(DioConfig);
+ * @endcode
+ * 
+ * @see SPI_ConfigGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ * 
+*****************************************************************************/
+void SPI_Init(SpiConfig_t const * const Config)
+{
+    /** TODO: Define implementation*/
+}
+
+/**********************************************************************
+ * Function: SPI_Transfer()
+*//**
+ *\b Description:
+ * This function is used to initialize a data transfer on the SPI bus. 
+ * 
+ * PRE-CONDITION: SPI_Init must be called with valid configuration data.
+ * PRE-CONDITION: SpiTransfer_t must be configured for the device.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * 
+ * POST-CONDITION: Data transferred based on configuration.
+ * 
+ * @param[in]   Config is a configured structure describing the data  
+ * transfer that occurs.
+ *
+ * 
+ * @return  void
+ * 
+ * \b Example:
+ * @code
+ *  const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * @endcode
+ * 
+ * @see SPI_ConfigGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ * 
+ **********************************************************************/
+void SPI_Transfer(uint16_t *data, uint16_t size)
+{
+    /** TODO: define implementation*/
+}
+
+/**********************************************************************
+ * Function: SPI_registerWrite()
+*//**
+ *\b Description:
+ * This function is used to directly address and modify a SPI register.
+ * The function should be used to access specialized functionality in 
+ * the SPI peripheral that is not exposed by any other function of the
+ * interface.
+ * 
+ * PRE-CONDITION: Address is within the boundaries of the SPI register
+ * address space.
+ * 
+ * POST-CONDITION: The register located at address with be updated with
+ * value.
+ * 
+ * @param[in]   address is a register address within the SPI peripheral
+ *              map.
+ * @param[in]   value is the value to set the SPI register. 
+ * 
+ * @return void
+ * 
+ * \b Example
+ * @code
+ *  SPI_registerWrite(0x1000, 0x15);
+ * @endcode
+ * 
+ * @see SPI_ConfigGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ * 
+**********************************************************************/  
+void SPI_RegisterWrite(uint32_t address, TYPE value)
+{
+    /** TODO: define implementation*/
+}
+
+/**********************************************************************
+ * Function: SPI_registerRead()
+*//**
+ *\b Description:
+ * This function is used to directly address a SPI register. The 
+ * function should be used to access specialized functionality in the 
+ * SPI peripheral that is not exposed by any other function of the 
+ * interface.
+ * 
+ * PRE-CONDITION: Address is within the boundaries of the SPI register 
+ * address space.
+ * 
+ * POST-CONDITION: The value stored in the register is returned to the 
+ * caller.
+ * 
+ * @param[in]   address is the address of the SPI register to read.
+ * 
+ * @return  The current value of the SPI register.
+ * 
+ * \b Example:
+ * @code
+ * type spiValue = SPI_registerRead(0x1000);
+ * @endcode
+ * 
+ * @see SPI_ConfigGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ *
+ **********************************************************************/
+TYPE SPI_RegisterRead(uint32_t address)
+{
+    /** TODO: Define implementation*/
+}

--- a/SPI/src/spi_cfg.c
+++ b/SPI/src/spi_cfg.c
@@ -35,17 +35,15 @@
  * Peripheral Interface. Each row represent a single SPI configuration.
  * Each column is representing a member of the SpiConfig_t structure. This 
  * table is read in by SPI_Init, where each channel is then set up based on 
- * this table. The NUMBER_DIGITAL_PINS constant should be agreed with the 
+ * this table. The SPI_CHANNELS_NUMBER constant should be agreed with the 
  * number of row.
 */
 const SpiConfig_t SpiConfig[] = 
 {
-   /** TODO: Populate according to the SPI configuration and number of pins*/
 /*                                                          
  *  Mode       Hierarchy   Baud rate   Frame    Type             Size               
 */
-   {SPI_MODE3, SPI_MASTER, SPI_FPCKL4, SPI_MSB, SPI_FULL_DUPLEX, SPI_8BITS},
-
+   {SPI_MODE3, SPI_MASTER, SPI_FPCLK4, SPI_MSB, SPI_FULL_DUPLEX, SPI_8BITS},
 };
 
 /*****************************************************************************

--- a/SPI/src/spi_cfg.c
+++ b/SPI/src/spi_cfg.c
@@ -1,0 +1,94 @@
+/**
+ * @file spi_cfg.c
+ * @author Jose Luis Figueroa.
+ * @brief This module contains the implementation for the Serial Peripheral
+ * Interface (SPI).
+ * @version 1.0
+ * @date 2023-07-14
+ * 
+ * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * 
+ */
+
+/*****************************************************************************
+* Includes
+*****************************************************************************/
+#include "spi_cfg.h"
+
+/*****************************************************************************
+* Module Preprocessor Constants
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Preprocessor Macros
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Typedefs
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Variable Definitions
+*****************************************************************************/
+/**
+ * The following array contains the configuration data for each Serial 
+ * Peripheral Interface. Each row represent a single SPI configuration.
+ * Each column is representing a member of the SpiConfig_t structure. This 
+ * table is read in by SPI_Init, where each channel is then set up based on 
+ * this table. The NUMBER_DIGITAL_PINS constant should be agreed with the 
+ * number of row.
+*/
+const SpiConfig_t SpiConfig[] = 
+{
+   /** TODO: Populate according to the SPI configuration and number of pins*/
+/*                                                          
+ *  Mode       Hierarchy   Baud rate   Frame    Type             Size               
+*/
+   {SPI_MODE3, SPI_MASTER, SPI_FPCKL4, SPI_MSB, SPI_FULL_DUPLEX, SPI_8BITS},
+
+};
+
+/*****************************************************************************
+* Function Prototypes
+*****************************************************************************/
+
+/*****************************************************************************
+* Function Definitions
+*****************************************************************************/
+/*****************************************************************************
+ * Function: SPI_ConfigGet()
+*/
+/**
+*\b Description:
+ * This function is used to initialize the SPI based on the configuration
+ * table defined in spi_cfg module.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0)
+ * POST-CONDITION: A constant pointer to the first member of the  
+ * configuration table will be returned.
+ * @return A pointer to the configuration table.
+ * 
+ * \b Example: 
+ * @code
+ * const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * 
+ * SPI_Init(SpiConfig);
+ * @endcode
+ * 
+ * @see SPI_ConfigGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ * 
+*****************************************************************************/
+const SpiConfig_t * const SPI_ConfigGet(void)
+{
+   /* The cast is performed to ensure that the address of the first element 
+    * of configuration table is returned as a constant pointer and not a
+    * pointer that can be modified
+   */
+  return (const SpiConfig_t*)&SpiConfig[0];
+
+}


### PR DESCRIPTION
Create an SPI driver. The driver consists of the following modules:
- spi_cfg.h
- spi_cfg.c
- spi.h
- spi.c

The spi_cfg.h and spi_cfg.c codes were updated to work with the Nucleo-F401RE.