### PR TITLE
Update SPI driver

### DIFF
--- a/DIO/include/dio.h
+++ b/DIO/include/dio.h
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "dio_cfg.h"    /*For dio configuration*/
 #include "stm32f4xx.h"  /*Microcontroller family header*/  

--- a/SPI slave/include/dio.h
+++ b/SPI slave/include/dio.h
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "dio_cfg.h"    /*For dio configuration*/
 #include "stm32f4xx.h"  /*Microcontroller family header*/  

--- a/SPI slave/include/dio.h
+++ b/SPI slave/include/dio.h
@@ -1,20 +1,13 @@
 /**
  * @file dio.h
  * @author Jose Luis Figueroa
- * @brief The interface definition for the dio. This is the header file for 
- * the definition of the interface for a Serial Peripheral Interface on 
+ * @brief The interface definition for the DIO. This is the header file for 
+ * the definition of the interface for a digital input/output peripheral on 
  * a standard microcontroller.
- * @version 1.0
- * @date 2023-03-18
+ * @version 1.1
+ * @date 2025-03-04
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
- * 
- * <br><b> - HISTORY OF CHANGES - </b>
- * 
- * <table align="left" style="width:800px">
- * <tr><td> Date    </td><td> Version </td><td> Description       </td></tr> 
- * <tr><td> 5/16/23 </td><td> 1.0     </td><td> Interface created </td></tr> 
- * </table><br><br>
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef DIO_H_
@@ -25,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+#include <assert.h>
 #include "dio_cfg.h"    /*For dio configuration*/
 #include "stm32f4xx.h"  /*Microcontroller family header*/  
 
@@ -43,6 +37,11 @@
 /*****************************************************************************
 * Typedefs
 *****************************************************************************/
+typedef struct
+{
+    DioPort_t Port;             /**< The I/O port */
+    DioPin_t Pin;               /**< The I/O pin */
+}DioPinConfig_t;
 
 /*****************************************************************************
 * Variables
@@ -55,10 +54,10 @@
 extern "C"{
 #endif
 
-void DIO_init(const DioConfig_t * const Config);
-DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin);
-void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State);
-void DIO_pinToggle(DioPort_t Port, DioPin_t Pin);
+void DIO_init(const DioConfig_t * const Config, size_t configSize);
+DioPinState_t DIO_pinRead(const DioPinConfig_t * const PinConfig);
+void DIO_pinWrite(const DioPinConfig_t * const PinConfig, DioPinState_t State);
+void DIO_pinToggle(const DioPinConfig_t * const PinConfig);
 void DIO_registerWrite(uint32_t address, uint32_t value);
 uint32_t DIO_registerRead(uint32_t address);
 

--- a/SPI slave/include/dio_cfg.h
+++ b/SPI slave/include/dio_cfg.h
@@ -4,10 +4,10 @@
  * @brief This module contains interface definitions for the Dio 
  * configuration. This is the header file for the definition of the
  * interface for retrieving the digital input/output configuration table.
- * @version 1.0
- * @date 2023-03-16
+ * @version 1.1
+ * @date 2025-03-04
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef DIO_CFG_H_
@@ -16,6 +16,7 @@
 /*****************************************************************************
 * Includes
 *****************************************************************************/
+#include <stdio.h>
 
 /*****************************************************************************
 * Preprocessor Constants
@@ -24,11 +25,6 @@
  * Defines the number of ports on the processor.
  */
 #define NUMBER_OF_PORTS 5U
-
-/** Set the value according with the number of digital input/output peripheral
- * channel (pins) used.
-*/
-#define NUMBER_DIGITAL_PINS 4
 
 /*****************************************************************************
 * Typedefs
@@ -212,6 +208,7 @@ extern "C"{
 #endif
 
 const DioConfig_t * const DIO_configGet(void);
+size_t DIO_configSizeGet(void);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/SPI slave/include/spi.h
+++ b/SPI slave/include/spi.h
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "spi_cfg.h"
 #include "stm32f4xx.h"   

--- a/SPI slave/include/spi.h
+++ b/SPI slave/include/spi.h
@@ -1,13 +1,13 @@
 /**
  * @file spi.h
  * @author Jose Luis Figueroa 
- * @brief The interface definition for the spi. This is the header file for 
+ * @brief The interface definition for the SPI. This is the header file for 
  * the definition of the interface for a Serial Peripheral Serial (SPI) on 
  * a standard microcontroller.
- * @version 1.0
- * @date 2023-07-14
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. All rights reserved.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. All rights reserved.
  * 
  */
 #ifndef SPI_H_
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+#include <assert.h>
 #include "spi_cfg.h"
 #include "stm32f4xx.h"   
 
@@ -36,6 +37,12 @@
 /*****************************************************************************
 * Typedefs
 *****************************************************************************/
+typedef struct
+{
+    SpiChannel_t Channel;           /**< The SPI channel */
+    uint16_t size;                  /**< The size of the data */
+    uint16_t *data;                 /**< The data to be sent */
+}SpiTransferConfig_t;
 
 /*****************************************************************************
 * Variables
@@ -48,9 +55,9 @@
 extern "C"{
 #endif
 
-void SPI_init(const SpiConfig_t * const Config);
-void SPI_transfer(SpiChannel_t Channel, uint16_t *data, uint16_t size);
-void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size);
+void SPI_init(const SpiConfig_t * const Config, size_t configSize);
+void SPI_transfer(const SpiTransferConfig_t * const TransferConfig);
+void SPI_receive(const SpiTransferConfig_t * const TransferConfig);
 void SPI_registerWrite(uint32_t address, uint32_t value);
 uint16_t SPI_registerRead(uint32_t address);
 

--- a/SPI slave/include/spi_cfg.h
+++ b/SPI slave/include/spi_cfg.h
@@ -2,50 +2,44 @@
  * @file spi_cfg.h
  * @author Jose Luis Figueroa 
  * @brief This module contains interface definitions for the SPI
- * configuration. This is the header file for the definition of the
- * interface for retrieving the Serial Peripheral interface
- * configuration table.
- * @version 1.0
- * @date 2023-07-14
+ * configuration. This is the header file for the definition of the interface
+ * for retrieving the Serial Peripheral interface configuration table.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef SPI_CFG_H_
 #define SPI_CFG_H_
 
-/**********************************************************************
+/*****************************************************************************
 * Includes
-**********************************************************************/
+*****************************************************************************/
+#include <stdio.h>
 
-/**********************************************************************
+/****************************************************************************
 * Preprocessor Constants
-**********************************************************************/
+*****************************************************************************/
 /** 
  * Defines the number of ports on the processor.
  */
 #define SPI_PORTS_NUMBER 4U
 
-/** 
- * Set the value according with the number of Serial Peripheral 
- * interface channels to be used.
-*/
-#define SPI_CHANNELS_NUMBER 1
-
-/**********************************************************************
+/****************************************************************************
 * Typedefs
-**********************************************************************/
+*****************************************************************************/
 /**
  * Define the SPI channels on the MCU device. It is used to specify
  * SPI channel to configure the register map.
 */
 typedef enum
 {
-    SPI_CHANNEL1,       /**< SPI Channel 1*/
-    SPI_CHANNEL2,       /**< SPI Channel 2*/
-    SPI_CHANNEL3,       /**< SPI Channel 3*/
-    SPI_CHANNEL4,       /**< SPI Channel 4*/
-    SPI_MAX_CHANNEL     /**< Define the maximum SPI Channel*/
+    SPI_CHANNEL1,   /**< SPI Channel 1*/
+    SPI_CHANNEL2,   /**< SPI Channel 2*/
+    SPI_CHANNEL3,   /**< SPI Channel 3*/
+    SPI_CHANNEL4,   /**< SPI Channel 4*/
+    SPI_MAX_CHANNEL /**< Maximum SPI Channel*/
 }SpiChannel_t;
 
 /**
@@ -130,7 +124,7 @@ typedef enum
 {
     SPI_8BITS,      /**< 8 bits data is selected for communication*/
     SPI_16BITS,     /**< 16 bits data is selected for communication*/
-    SPI_MAX_BITS    /**< Define the maximum number of bits*/
+    SPI_MAX_BITS    /**< Maximum number of bits*/
 }SpiDataSize_t;
 
 /**
@@ -158,6 +152,7 @@ extern "C"{
 #endif
 
 const SpiConfig_t * const SPI_ConfigGet(void);
+size_t SPI_configSizeGet(void);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/SPI slave/src/dio.c
+++ b/SPI slave/src/dio.c
@@ -1,11 +1,11 @@
 /**
  * @file dio.c
  * @author Jose Luis Figueroa
- * @brief The implementation for the dio
- * @version 1.0
- * @date 2023-03-19
+ * @brief The implementation for the DIO driver.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 /*****************************************************************************
@@ -60,9 +60,7 @@ static uint32_t volatile * const pupdrRegister[NUMBER_OF_PORTS] =
     (uint32_t*)&GPIOH->PUPDR
 };
 
-/*
- * Defines a array of pointers to the GPIO port input data register.
-*/
+/* Defines a array of pointers to the GPIO port input data register. */
 static uint32_t volatile * const idrRegister[NUMBER_OF_PORTS] =  
 {
     (uint32_t*)&GPIOA->IDR, (uint32_t*)&GPIOB->IDR, (uint32_t*)&GPIOC->IDR,
@@ -97,27 +95,33 @@ static uint32_t volatile * const afrRegister[NUMBER_OF_PORTS] =
  * Function: DIO_init()
 *//**
 *\b Description:
- * This function is used to initialize the Dio based on the configuration  
+ * This function is used to initialize the DIO based on the configuration  
  * table defined in dio_cfg module.
  * 
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
- * PRE-CONDITION: NUMBER_OF_PORTS > 0 <br>
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
  * PRE-CONDITION: Configuration table needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: NUMBER_OF_PORTS > 0 <br>
+ * PRE-CONDITION: The setting is within the maximum values (DIO_MAX). <br>
  * 
  * POST-CONDITION: The DIO peripheral is set up with the configuration 
  * settings.
  * 
  * @param[in]   Config is a pointer to the configuration table that contains 
  *               the initialization for the peripheral.
+ * @param[in]   configSize is the size of the configuration table.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  const DioConfig_t * const DioConfig = DIO_configGet();
- *  DIO_init(DioConfig);
+ * const Dio_ConfigType_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * DIO_Init(DioConfig, configSize);
  * @endcode
  * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -126,11 +130,18 @@ static uint32_t volatile * const afrRegister[NUMBER_OF_PORTS] =
  * @see DIO_registerRead
  * 
 *****************************************************************************/
-void DIO_init(const DioConfig_t * const Config)
+void DIO_init(const DioConfig_t * const Config, size_t configSize)
 {
     /* Loop through all the elements of the configuration table. */
-    for(uint8_t i=0; i<NUMBER_DIGITAL_PINS; i++)
+    for(uint8_t i=0; i<configSize; i++)
     {
+        /* Prevent to assign a value out of the range of the port and pin.
+         * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+         * value can cause a memory violation.
+        */
+        assert(Config[i].Port < DIO_MAX_PORT);
+        assert(Config[i].Pin < DIO_MAX_PIN);
+
         /* 
          * Set the mode of the Dio pin on the GPIO port mode register. 
          * Multiply the pin number (Config[i].Pin) by two as MODER uses two 
@@ -159,7 +170,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            printf("This Mode does not exist\n");
+            assert(Config[i].Mode < DIO_MAX_MODE);
         }
 
         /*
@@ -176,7 +187,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            printf("This output type does not exist\n");
+            assert(Config[i].Type < DIO_MAX_TYPE);
         }
 
         /*
@@ -206,7 +217,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            printf("The output speed does not exist\n");
+            assert(Config[i].Speed < DIO_MAX_SPEED);
         }
 
         /*
@@ -232,7 +243,7 @@ void DIO_init(const DioConfig_t * const Config)
        }
        else
        {
-            printf("The port register does not exist");
+            assert(Config[i].Resistor < DIO_MAX_RESISTOR);
        }
 
         /*
@@ -351,7 +362,11 @@ void DIO_init(const DioConfig_t * const Config)
             *afrRegister[Config[i].Port] |= (2UL<<(Config[i].Pin*4));
             *afrRegister[Config[i].Port] |= (4UL<<(Config[i].Pin*4));
             *afrRegister[Config[i].Port] |= (8UL<<(Config[i].Pin*4));
-       } 
+       }
+       else
+       {
+            assert(Config[i].Function < DIO_MAX_FUNCTION);
+       }
 
     }
 }
@@ -360,25 +375,36 @@ void DIO_init(const DioConfig_t * const Config)
  * Function: DIO_pinRead()
 *//**
  *\b Description:
- * This function is used to read the state of a dio pin.
+ * This function is used to reads the state of a specified pin.
+ * This function reads the state of a digital input/output pin specified by
+ * the DioPinConfig_t structure, which contains the port and pin information.
  * 
  * PRE-CONDITION: The pin is configured as INPUT <br>
  * PRE-CONDITION: The pin is configured as GPIO <br>
- * PRE-CONDITION: The Port is within the maximum DioPort_t.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
  * PRE-CONDITION: The Pin is within the maximum DioPin_t. 
- * definition.
+ * definition. <br>
  * 
- * POST-CONDITION: The channel state is returned.
+ * POST-CONDITION: The channel state is returned. <br>
  * 
- * @param[in]   Port is the DioPort_t that represents a port.
- * @param[in]   Pin is the DioPin_t that represents a pin.
- * @return      The state of the channel as HIGH or LOW.
+ * @param[in] PinConfig A pointer to a structure containing the port and pin 
+ * to be read.
+ * 
+ * @return    DioPinState_t The state of the pin (high or low).
  * 
  * \b Example:
  * @code
- *  bool pin = DIO_pinRead(DIO_PC, DIO_PC5);
+ * const DioPinConfig_t  UserButton1= 
+ * {
+ *      .Port = DIO_PC, 
+ *      .Pin = DIO_PC13
+ * };
+ *  bool pin = DIO_pinRead(&UserButton1);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -387,12 +413,19 @@ void DIO_init(const DioConfig_t * const Config)
  * @see DIO_registerRead
  * 
 **********************************************************************/
-DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
+DioPinState_t DIO_pinRead(const DioPinConfig_t * const PinConfig)
 {
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
     /* Read the port associated with the desired pin */
-    uint16_t portState = *idrRegister[Port];
+    uint16_t portState = *idrRegister[PinConfig->Port];
     /* Determinate the Port bit associated with this pin*/
-    uint16_t pinMask = (1UL<<(Pin));
+    uint16_t pinMask = (1UL<<(PinConfig->Pin));
 
     return ((portState & pinMask) ? DIO_HIGH : DIO_LOW); 
 }
@@ -402,31 +435,45 @@ DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
 *//**
  *\b Description:
  * This function is used to write the state of a pin as either logic 
- * high or low through the use of the DioChannel_t enum to select the 
- * channel and the DioPinState_t to define the desired state.
+ * high or low. it reads the state of a digital input/output pin 
+ * specified by the DioPinConfig_t structure and the DioPinState_t to 
+ * define the desired state, which contains the port and pin 
+ * information.
  * 
  * PRE-CONDITION: The pin is configured as OUTPUT <br>
  * PRE-CONDITION: The pin is configured as GPIO <br>
- * PRE-CONDITION: The pin is within the maximum DioChannel_t .
- * definition.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
+ * PRE-CONDITION: The Pin is within the maximum DioPin_t. <br>
+ * PRE-CONDITION: The State is within the maximum DioPinState_t. <br>
  * 
- * POST-CONDITION: The channel state will be Stated.
+ * POST-CONDITION: The channel state is Stated. <br>
  * 
- * @param[in]   Port is the GPIO to write using the DioPort_t enum.
- * @param[in]   Pin is the bit to write using the DioPin_t enum 
- *              definition.
+ * @param[in]   pinConfig A pointer to a structure containing the port 
+ *              and pin to be written.
  * @param[in]   State is HIGH or LOW as defined in the DioPinState_t 
  *              enum. 
- *          
  * 
- * @return  void
+ * @return      void
  * 
  * \b Example:
  * @code
- *  DIO_pinWrite(DIO_PA, DIO_PA1, LOW);  //Set the PORT pin low
- *  DIO_pinWrite(DIO_PB, DIO_PB3, HIGH); //Set the PORT pin high
+ * const DioPinConfig_t  UserLED1= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA5
+ * };
+ * const DioPinConfig_t  UserLED2= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA6
+ * };
+ * DIO_pinWrite(&UserLED1, LOW);    //Set the pin low
+ * DIO_pinWrite(&UserLED2, HIGH);   //Set the pin high
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -435,19 +482,26 @@ DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
  * @see DIO_registerRead
  * 
  **********************************************************************/
-void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
+void DIO_pinWrite(const DioPinConfig_t * const PinConfig, DioPinState_t State)
 {
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
     if(State == DIO_HIGH)
     {
-        *odrRegister[Port] |= (1UL<<(Pin));
+        *odrRegister[PinConfig->Port] |= (1UL<<(PinConfig->Pin));
     }
     else if (State == DIO_LOW)
     {
-        *odrRegister[Port] &= ~(1UL<<Pin);
+        *odrRegister[PinConfig->Port] &= ~(1UL<<(PinConfig->Pin));
     }
     else
     {
-        printf("This option does not exist");
+        assert(State < DIO_PIN_STATE_MAX);
     }
 }
 
@@ -455,25 +509,36 @@ void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
  * Function: DIO_pinToggle()
 *//**
  *\b Description:
- * This function is used to toggle the current state of a pin.
+ * This function is used to toggle the current state of a pin. 
+ * This function reads the state of a digital input/output pin 
+ * specified by the DioPinConfig_t structure, which contains the port 
+ * and pin information.
  * 
  * PRE-CONDITION: The channel is configured as output <br>
  * PRE-CONDITION: The channel is configured as GPIO <br>
- * PRE-CONDITION: The channel is within the maximum DioChannel_t 
- * definition.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
+ * PRE-CONDITION: The Pin is within the maximum DioPin_t. <br>
  *
- * POST-CONDITION:
+ * POST-CONDITION: The channel state is toggled. <br>
  * 
- * @param[in]   Port is the GPIO to write using the DioPort_t enum.
- * @param[in]   Pin is the bit from the DioPin_t that is to be modified
+ * @param[in]   pinConfig A pointer to a structure containing the port 
+ *              and pin to be toggled.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  DIO_pinToggle(DIO_PA, DIO_PA3);
+ * const DioPinConfig_t  UserLED1= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA5
+ * };
+ * DIO_pinToggle(&UserLED1);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -482,29 +547,36 @@ void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
  * @see DIO_registerRead
  * 
  **********************************************************************/
-void DIO_pinToggle(DioPort_t Port, DioPin_t Pin)
+void DIO_pinToggle(const DioPinConfig_t * const PinConfig)
 {
-    *odrRegister[Port] ^= (1UL<<Pin);
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
+    *odrRegister[PinConfig->Port] ^= (1UL<<(PinConfig->Pin));
 }
 
 /**********************************************************************
  * Function: DIO_registerWrite()
 *//**
  *\b Description:
- * This function is used to directly address and modify a Dio register.
+ * This function is used to directly address and modify a GPIO register.
  * The function should be used to access specialized functionality in 
- * the Dio peripheral that is not exposed by any other function of the
+ * the DIO peripheral that is not exposed by any other function of the
  * interface.
  * 
- * PRE-CONDITION: Address is within the boundaries of the Dio register
- * address space.
+ * PRE-CONDITION: Address is within the boundaries of the DIO register
+ * address space. <br>
  * 
  * POST-CONDITION: The register located at address with be updated with
- * value.
+ * value. <br>
  * 
- * @param[in]   address is a register address within the Dio peripheral
+ * @param[in]   address is a register address within the DIO peripheral
  *              map.
- * @param[in]   value is the value to set the Dio register. 
+ * @param[in]   value is the value to set the DIO register. 
  * 
  * @return void
  * 
@@ -513,10 +585,12 @@ void DIO_pinToggle(DioPort_t Port, DioPin_t Pin)
  *  DIO_registerWrite(0x1000, 0x15);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
- * @see DIO_channelRead
- * @see DIO_channelWrite
- * @see DIO_channelToggle
+ * @see DIO_pinRead
+ * @see DIO_pinWrite
+ * @see DIO_pinToggle
  * @see DIO_registerWrite
  * @see DIO_registerRead
  * 
@@ -537,10 +611,10 @@ void DIO_registerWrite(uint32_t address, uint32_t value)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the Dio register 
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The value stored in the register is returned to the 
- * caller.
+ * caller. <br>
  * 
  * @param[in]   address is the address of the Dio register to read.
  * 
@@ -551,10 +625,12 @@ void DIO_registerWrite(uint32_t address, uint32_t value)
  * type dioValue = DIO_registerRead(0x1000);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
- * @see DIO_channelRead
- * @see DIO_channelWrite
- * @see DIO_channelToggle
+ * @see DIO_pinRead
+ * @see DIO_pinWrite
+ * @see DIO_pinToggle
  * @see DIO_registerWrite
  * @see DIO_registerRead
  *

--- a/SPI slave/src/dio_cfg.c
+++ b/SPI slave/src/dio_cfg.c
@@ -3,10 +3,10 @@
  * @author Jose Luis Figueroa
  * @brief This module contains the implementation for the digital 
  * input/output peripheral configuration.
- * @version 1.0
- * @date 2023-03-17
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 
@@ -35,14 +35,15 @@
  * input/output peripheral channel (pin). Each row represent a single pin.
  * Each column is representing a member of the DioConfig_t structure. This 
  * table is read in by Dio_Init, where each channel is then set up based on 
- * this table.
+ * this table. The NUMBER_DIGITAL_PINS constant should be accorded with the
+ * number of rows.
 */
 const DioConfig_t DioConfig[] = 
 {
 /*                                                          
- *  Port    Pin      Mode        Type(Output)     Speed          Resistor         Function
+ *  Port    Pin      Mode        Type           Speed          Resistor         Function
  *                
-*/
+*/ 
    {DIO_PA, DIO_PA4, DIO_INPUT,    DIO_PUSH_PULL, DIO_LOW_SPEED, DIO_NO_RESISTOR, DIO_AF5},
    {DIO_PA, DIO_PA5, DIO_FUNCTION, DIO_PUSH_PULL, DIO_LOW_SPEED, DIO_NO_RESISTOR, DIO_AF5},
    {DIO_PA, DIO_PA6, DIO_FUNCTION, DIO_PUSH_PULL, DIO_LOW_SPEED, DIO_NO_RESISTOR, DIO_AF5},
@@ -64,18 +65,23 @@ const DioConfig_t DioConfig[] =
  * This function is used to initialize the DIO based on the configuration
  * table defined in dio_cfg module.
  * 
- * PRE-CONDITION: configuration table needs to be populated (sizeof > 0)
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
  * POST-CONDITION: A constant pointer to the first member of the  
- * configuration table will be returned.
- * @return A pointer to the configuration table.
+ * configuration table will be returned.<br>
+ * 
+ * @return A pointer to the configuration table. <br>
  * 
  * \b Example: 
  * @code
- * const Dio_ConfigType_t * const DioConfig = DIO_configGet();
+ * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
  * 
- * DIO_Init(DioConfig);
+ * DIO_Init(DioConfig, configSize);
  * @endcode
  * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_channelRead
  * @see DIO_channelWrite
@@ -92,4 +98,40 @@ const DioConfig_t * const DIO_configGet(void)
    */
   return (const DioConfig_t*)&DioConfig[0];
 
+}
+
+/*****************************************************************************
+ * Function: DIO_getConfigSize()
+*/
+/**
+*\b Description:
+ * This function is used to get the size of the configuration table.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
+ * POST-CONDITION: The size of the configuration table will be returned. <br>
+ * 
+ * @return The size of the configuration table.
+ * 
+ * \b Example: 
+ * @code
+ * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * DIO_Init(DioConfig, configSize);
+ * @endcode
+ * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
+ * @see DIO_init
+ * @see DIO_channelRead
+ * @see DIO_channelWrite
+ * @see DIO_channelToggle
+ * @see DIO_registerWrite
+ * @see DIO_registerRead
+ * 
+*****************************************************************************/
+size_t DIO_configSizeGet(void)
+{
+   return sizeof(DioConfig)/sizeof(DioConfig[0]);
 }

--- a/SPI slave/src/main.c
+++ b/SPI slave/src/main.c
@@ -5,8 +5,11 @@
  * the master continuously.
  * @version 1.0
  * @date 2023-08-30
- * @note The microcontroller internal system clock is 16MHz.
- * The baud rate is divided by 4, then, baud rate = 4MHz.
+ * @note Take into account the following considerations:
+ * + The microcontroller internal system clock is 16MHz. The baud rate is 
+ *   divided by 4, then, baud rate = 4MHz.
+ * + It is necessary to connect the Logic Analyzer to the SPI1 pins to debug
+ *   or test the SPI communication.
  * 
  * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
  * 
@@ -25,20 +28,34 @@ int main(void)
 
     /* Get the address of the Configuration table for DIO*/
     const DioConfig_t * const DioConfig = DIO_configGet();
+    /* Get the size of the configuration table*/
+    size_t configSizeDio = DIO_configSizeGet();
     /* Initialize the DIO pins according to the configuration table*/
-    DIO_init(DioConfig);
+    DIO_init(DioConfig, configSizeDio);
     
     /* Get the address of the configuration table for SPI*/
     const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+    /* Get the size of the configuration table*/
+    size_t configSizeSpi = SPI_configSizeGet();
     /* Initialize the SPI channel according to the configuration table*/
-    SPI_init(SpiConfig);
+    SPI_init(SpiConfig, configSizeSpi);
 
     /* Data to be sent*/
-    uint16_t data = 0x66;
+    uint16_t data[1]={0x66};
+
+    /* SPI transfer configuration*/
+    SpiTransferConfig_t TransferConfig =
+    {
+        .Channel = SPI_CHANNEL1,
+        .size = sizeof(data)/sizeof(data[0]),
+        .data = data
+    };
+
 
     while(1)
     {
         /* Transmit data*/
-        SPI_transfer(SPI_CHANNEL1, &data, 1);
+        SPI_transfer(&TransferConfig);
+
     }
 }

--- a/SPI slave/src/spi.c
+++ b/SPI slave/src/spi.c
@@ -1,11 +1,11 @@
 /**
  * @file spi.c
  * @author Jose Luis Figueroa 
- * @brief The implementation for the SPI.
- * @version 1.0
- * @date 2023-07-14
+ * @brief The implementation for the SPI Driver.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 /*****************************************************************************
@@ -67,27 +67,32 @@ static uint16_t volatile * const dataRegister[SPI_PORTS_NUMBER] =
  * Function: SPI_init()
 *//**
 *\b Description:
- * This function is used to initialize the spi based on the configuration  
+ * This function is used to initialize the SPI based on the configuration  
  * table defined in spi_cfg module.
  * 
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
- * PRE-CONDITION: SPI pins should be configured using GPIO driver.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI pins should be configured using GPIO driver. <br>
  * PRE-CONDITION: Configuration table needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The setting is within the maximum values (SPI_MAX). <br>
  *
- * POST-CONDITION: The peripheral is set up with the configuration settings.
+ * POST-CONDITION: The peripheral is set up with the configuration settings. <br>
  * 
  * @param[in]   Config is a pointer to the configuration table that contains 
- *               the initialization for the peripheral.
+ *               the initialization for the peripheral. 
+ * @param[in]   configSize is the size of the configuration table. 
  * 
- * @return  void
- * 
+ * @return  void 
+ *  
  * \b Example:
  * @code
  *  const SpiConfig_t * const SpiConfig = SPI_configGet();
- *  SPI_Init(DioConfig);
+ *  size_t configSize = SPI_configSizeGet();
+ * 
+ *  SPI_Init(DioConfig, configSize);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_getConfigSize
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
@@ -95,11 +100,17 @@ static uint16_t volatile * const dataRegister[SPI_PORTS_NUMBER] =
  * @see SPI_CallbackRegister
  * 
 *****************************************************************************/
-void SPI_init(const SpiConfig_t * const Config)
+void SPI_init(const SpiConfig_t * const Config, size_t configSize)
 {
     /**Loop through all the elements of the configuration table.*/
-    for(uint8_t i=0; i<SPI_CHANNELS_NUMBER; i++)
+    for(uint8_t i=0; i<configSize; i++)
     {
+        /* Prevent to assign a value out of the range of the channels.
+         * The registers arrays are limited to the SPI_PORTS_NUMBER, higher 
+         * value can cause a memory violation.
+        */
+       assert(Config[i].Channel < SPI_MAX_CHANNEL);
+
         /**Set the configuration of the SPI on the control register 1*/
         /**Set the Clock phase and polarity modes*/
         if(Config[i].Mode == SPI_MODE0)
@@ -124,7 +135,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This mode does not exist\n");
+            assert(Config[i].Mode < SPI_MAX_MODE);
         }
 
         /**Set the hierarchy of the device*/
@@ -138,7 +149,7 @@ void SPI_init(const SpiConfig_t * const Config)
         } 
         else
         {
-            printf("This hierarchy does not exist\n");
+            assert(Config[i].Hierarchy < SPI_MAX_HIERARCHY);
         }
 
         /**Set the baud rate of the device*/
@@ -192,7 +203,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This baud rate does not exist\n");
+            assert(Config[i].BaudRate < SPI_MAX_FPCLK);
         }
 
         /**Set the slave select pin management for the device*/
@@ -213,7 +224,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This slave select pin option does not exist\n");
+            assert(Config[i].SlaveSelect < SPI_MAX_NSS);
         }
 
         /**Set the frame format of the device*/
@@ -227,7 +238,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This frame format does not exist\n");
+            assert(Config[i].FrameFormat < SPI_MAX_FF);
         }
 
         /**Set the data transfer type of the device*/
@@ -241,7 +252,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This data transfer type does not exist");
+            assert(Config[i].TypeTransfer < SPI_MAX_DF);
         }
 
         /**Set the data frame format (size) of the device*/
@@ -255,7 +266,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This data size does not exist\n");
+            assert(Config[i].DataSize < SPI_MAX_BITS);
         }
 
         /**Enable the SPI module*/
@@ -264,114 +275,153 @@ void SPI_init(const SpiConfig_t * const Config)
 
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_Transfer()
 *//**
  *\b Description:
- * This function is used to initialize a data transfer on the SPI bus. 
+ * This function is used to initialize a data transfer on the SPI bus. This 
+ * function is used to send data to a slave device specified by the 
+ * SpiTransferConfig_t structure, which contains the channel, size, and data.
  * 
- * PRE-CONDITION: SPI_Init must be called with valid configuration data.
- * PRE-CONDITION: SpiTransfer_t needs to be populated.
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI_Init must be called with valid configuration data. <br>
+ * PRE-CONDITION: SpiTransferConfig_t needs to be populated. <br>
+ * PRE-CONDITION: The Channel is within the maximum SpiChannel_t. <br>
+ * PRE-CONDITION: The size is greater than 0. <br>
+ * PRE-CONDITION: The data is not NULL. <br>
  * 
- * POST-CONDITION: Data transferred based on configuration.
+ * POST-CONDITION: Data transferred based on configuration. <br>
  * 
- * @param[in]   data(pointer) is the information to be sent.
- * @param[in]   size is data size.
+ * @param[in] SpiTransferConfig A pointer to a structure containing the
+ * channel, size, and data to be read.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  SPI_Transfer(*data, size);
+ * uint16_t data[] = {0x56};
+ * SpiTransferConfig_t TransferConfig =
+ * {
+ *     .Channel = SPI_CHANNEL1,
+ *     .size = sizeof(data)/sizeof(data[0]),
+ *     .data = data
+ * };
+ * SPI_Transfer(&TransferConfig);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_getConfigSize
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  * 
- **********************************************************************/
-void SPI_transfer(SpiChannel_t Channel, uint16_t *data, uint16_t size)
+ ****************************************************************************/
+void SPI_transfer(const SpiTransferConfig_t * const TransferConfig)
 {
-    for(uint16_t i=0; i<size; i++)
+    /* Prevent to assign a value out of the range of the channel*/
+    assert(TransferConfig->Channel < SPI_MAX_CHANNEL);
+    /* Prevent to use an empty data size*/
+    assert(TransferConfig->size > 0);
+    /* Prevent to use an empty data transfer*/
+    assert(TransferConfig->data != NULL);
+
+    for (uint16_t i = 0; i < TransferConfig->size; i++)
     {
         /* Wait until TXE is set (buffer empty)*/
-        while(!(*statusRegister[Channel] & SPI_SR_TXE))
+        while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_TXE))
         {
             asm("nop");
         }
-        *dataRegister[Channel] = data[i];
+        *dataRegister[TransferConfig->Channel] = TransferConfig->data[i];
     }
 
     /* Wait until TXE is set to ensure the bus is empty*/
-    while(!(*statusRegister[Channel] & SPI_SR_TXE))
+    while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_TXE))
     {
         asm("nop");
     }
 
     /* Wait until bus is not busy to reset*/
-    while(*statusRegister[Channel] & SPI_SR_BSY)
+    while(*statusRegister[TransferConfig->Channel] & SPI_SR_BSY)
     {
         asm("nop");
     }
 
     /* Clear OVR bit (Overrun flag) in case of error*/
     uint16_t clearingFlag;
-    clearingFlag = *dataRegister[Channel];
-    clearingFlag = *statusRegister[Channel];
+    clearingFlag = *dataRegister[TransferConfig->Channel];
+    clearingFlag = *statusRegister[TransferConfig->Channel];
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_Receive()
 *//**
  *\b Description:
- * This function is used to initialize a data reception on the SPI bus. 
+ * This function is used to initialize a data reception on the SPI bus. This 
+ * function is used to receive data specified by the  SpiTransferConfig_t 
+ * structure, which contains the channel, size, and data.
  * 
- * PRE-CONDITION: SPI_Init must be called with valid configuration data.
- * PRE-CONDITION: SpiTransfer_t needs to be populated.
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI_Init must be called with valid configuration data. <br>
+ * PRE-CONDITION: SpiTransferConfig_t needs to be populated. <br>
+ * PRE-CONDITION: The Channel is within the maximum SpiChannel_t. <br>
+ * PRE-CONDITION: The size is greater than 0. <br>
+ * PRE-CONDITION: The data is not NULL. <br>
  * 
  * POST-CONDITION: Data transferred based on configuration.
  * 
- * @param[in]   data(pointer) is the information to be sent.
- * @param[in]   size is data size.
+ * @param[in] SpiTransferConfig A pointer to a structure containing the 
+ * channel, size, and data to be read.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  SPI_Receive(*data, size);
+* uint16_t rxdata[1];
+ * SpiTransferConfig_t ReceiveConfig =
+ * {
+ *     .Channel = SPI_CHANNEL1,
+ *     .size = sizeof(rxdata)/sizeof(rxdata[0]),
+ *     .data = rxdata
+ * };
+ * SPI_receive(&ReceiveConfig);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_getConfigSize
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  * 
- **********************************************************************/
-void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
+ ****************************************************************************/
+void SPI_receive(const SpiTransferConfig_t * const TransferConfig)
 {
-    while(size)
+    /* Prevent to assign a value out of the range of the channel*/
+    assert(TransferConfig->Channel < SPI_MAX_CHANNEL);
+    /* Prevent to use an empty data size*/
+    assert(TransferConfig->size > 0);
+    /* Prevent to use an empty data transfer*/
+    assert(TransferConfig != NULL);
+
+    for (uint8_t i = 0; i < TransferConfig->size; i++)
     {
         /* Send dummy data (Recommended).*/
-        *dataRegister[Channel] = 0;
+        *dataRegister[TransferConfig->Channel] = 0;
         /* Wait for RXEN flag to be sent*/
-        while(!(*statusRegister[Channel] & SPI_SR_RXNE))
+        while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_RXNE))
         {
             asm("nop");
         }
         /* Read the data*/
-        *data++ = *dataRegister[Channel];
-        size--;
+        TransferConfig->data[i] = *dataRegister[TransferConfig->Channel];
     }
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_registerWrite()
 *//**
  *\b Description:
@@ -381,10 +431,10 @@ void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the SPI register
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The register located at address with be updated with
- * value.
+ * value. <br>
  * 
  * @param[in]   address is a register address within the SPI peripheral
  *              map.
@@ -397,21 +447,22 @@ void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
  *  SPI_registerWrite(0x1000, 0x15);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  * 
-**********************************************************************/  
+****************************************************************************/  
 void SPI_registerWrite(uint32_t address, uint32_t value)
 {
     volatile uint32_t * const registerPointer = (uint32_t*)address;
     *registerPointer = value;
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_registerRead()
 *//**
  *\b Description:
@@ -421,10 +472,10 @@ void SPI_registerWrite(uint32_t address, uint32_t value)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the SPI register 
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The value stored in the register is returned to the 
- * caller.
+ * caller. <br>
  * 
  * @param[in]   address is the address of the SPI register to read.
  * 
@@ -435,14 +486,15 @@ void SPI_registerWrite(uint32_t address, uint32_t value)
  * type spiValue = SPI_registerRead(0x1000);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  *
- **********************************************************************/
+ ****************************************************************************/
 uint16_t SPI_registerRead(uint32_t address)
 {
     volatile uint16_t * const registerPointer = (uint16_t *)address;

--- a/SPI slave/src/spi_cfg.c
+++ b/SPI slave/src/spi_cfg.c
@@ -3,10 +3,10 @@
  * @author Jose Luis Figueroa.
  * @brief This module contains the implementation for the Serial Peripheral
  * Interface (SPI).
- * @version 1.0
- * @date 2023-07-14
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 
@@ -35,8 +35,8 @@
  * Peripheral Interface. Each row represent a single SPI configuration.
  * Each column is representing a member of the SpiConfig_t structure. This 
  * table is read in by SPI_Init, where each channel is then set up based on 
- * this table. The SPI_CHANNELS_NUMBER constant should be accorded with the 
- * number of rows.
+ * this table. The SPI_CHANNELS_NUMBER constant should be agreed with the 
+ * number of row.
 */
 const SpiConfig_t SpiConfig[] = 
 {
@@ -63,19 +63,22 @@ const SpiConfig_t SpiConfig[] =
  * This function is used to initialize the SPI based on the configuration
  * table defined in spi_cfg module.
  * 
- * PRE-CONDITION: configuration table needs to be populated (sizeof > 0)
- * POST-CONDITION: A constant pointer to the first member of the  
- * configuration table will be returned.
- * @return A pointer to the configuration table.
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0). <br>
+ * POST-CONDITION: A constant pointer to the first member of the configuration 
+ * table will be returned. <br>
+ * 
+ * @return A pointer to the configuration table. <br>
  * 
  * \b Example: 
  * @code
  * const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * size_t configSize = DIO_configSizeGet();
  * 
- * SPI_Init(SpiConfig);
+ * SPI_Init(SpiConfig, configSize);
  * @endcode
- * 
- * @see SPI_ConfigGet
+ *
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
@@ -91,4 +94,39 @@ const SpiConfig_t * const SPI_ConfigGet(void)
    */
   return (const SpiConfig_t*)&SpiConfig[0];
 
+}
+
+/*****************************************************************************
+ * Function: SPI_configSizeGet()
+*/
+/**
+*\b Description:
+ * This function is used to get the size of the configuration table.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
+ * POST-CONDITION: The size of the configuration table will be returned. <br>
+ * 
+ * @return The size of the configuration table. <br>
+ * 
+ * \b Example: 
+ * @code
+ * const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * SPI_Init(SpiConfig, configSize);
+ * @endcode
+ * 
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ * 
+*****************************************************************************/
+size_t SPI_configSizeGet(void)
+{
+   return sizeof(SpiConfig)/sizeof(SpiConfig[0]);
 }

--- a/SPI/include/dio.h
+++ b/SPI/include/dio.h
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "dio_cfg.h"    /*For dio configuration*/
 #include "stm32f4xx.h"  /*Microcontroller family header*/  

--- a/SPI/include/spi.h
+++ b/SPI/include/spi.h
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "spi_cfg.h"
 #include "stm32f4xx.h"   

--- a/SPI/src/main.c
+++ b/SPI/src/main.c
@@ -4,8 +4,11 @@
  * @brief Implement the master SPI driver using Nucleo-F401RE. 
  * @version 1.0
  * @date 2025-03-13
- * @note The microcontroller internal system clock is 16MHz.
- * The baud rate is divided by 4, then, baud rate = 4MHz.
+ * @note Take into account the following considerations:
+ * + The microcontroller internal system clock is 16MHz. The baud rate is 
+ *   divided by 4, then, baud rate = 4MHz.
+ * + It is necessary to connect the Logic Analyzer to the SPI1 pins to debug
+ *   or test the SPI communication.
  * 
  * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 

--- a/SPI_Master/include/dio.h
+++ b/SPI_Master/include/dio.h
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "dio_cfg.h"    /*For dio configuration*/
 #include "stm32f4xx.h"  /*Microcontroller family header*/  

--- a/SPI_Master/include/dio.h
+++ b/SPI_Master/include/dio.h
@@ -1,20 +1,13 @@
 /**
  * @file dio.h
  * @author Jose Luis Figueroa
- * @brief The interface definition for the dio. This is the header file for 
+ * @brief The interface definition for the DIO. This is the header file for 
  * the definition of the interface for a digital input/output peripheral on 
  * a standard microcontroller.
- * @version 1.0
- * @date 2023-03-18
+ * @version 1.1
+ * @date 2025-03-04
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
- * 
- * <br><b> - HISTORY OF CHANGES - </b>
- * 
- * <table align="left" style="width:800px">
- * <tr><td> Date    </td><td> Version </td><td> Description       </td></tr> 
- * <tr><td> 5/16/23 </td><td> 1.0     </td><td> Interface created </td></tr> 
- * </table><br><br>
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef DIO_H_
@@ -25,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+#include <assert.h>
 #include "dio_cfg.h"    /*For dio configuration*/
 #include "stm32f4xx.h"  /*Microcontroller family header*/  
 
@@ -43,6 +37,11 @@
 /*****************************************************************************
 * Typedefs
 *****************************************************************************/
+typedef struct
+{
+    DioPort_t Port;             /**< The I/O port */
+    DioPin_t Pin;               /**< The I/O pin */
+}DioPinConfig_t;
 
 /*****************************************************************************
 * Variables
@@ -55,10 +54,10 @@
 extern "C"{
 #endif
 
-void DIO_init(const DioConfig_t * const Config);
-DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin);
-void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State);
-void DIO_pinToggle(DioPort_t Port, DioPin_t Pin);
+void DIO_init(const DioConfig_t * const Config, size_t configSize);
+DioPinState_t DIO_pinRead(const DioPinConfig_t * const PinConfig);
+void DIO_pinWrite(const DioPinConfig_t * const PinConfig, DioPinState_t State);
+void DIO_pinToggle(const DioPinConfig_t * const PinConfig);
 void DIO_registerWrite(uint32_t address, uint32_t value);
 uint32_t DIO_registerRead(uint32_t address);
 

--- a/SPI_Master/include/dio_cfg.h
+++ b/SPI_Master/include/dio_cfg.h
@@ -4,10 +4,10 @@
  * @brief This module contains interface definitions for the Dio 
  * configuration. This is the header file for the definition of the
  * interface for retrieving the digital input/output configuration table.
- * @version 1.0
- * @date 2023-03-16
+ * @version 1.1
+ * @date 2025-03-04
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef DIO_CFG_H_
@@ -16,6 +16,7 @@
 /*****************************************************************************
 * Includes
 *****************************************************************************/
+#include <stdio.h>
 
 /*****************************************************************************
 * Preprocessor Constants
@@ -24,11 +25,6 @@
  * Defines the number of ports on the processor.
  */
 #define NUMBER_OF_PORTS 5U
-
-/** Set the value according with the number of digital input/output peripheral
- * channel (pins) used.
-*/
-#define NUMBER_DIGITAL_PINS 4
 
 /*****************************************************************************
 * Typedefs
@@ -212,6 +208,7 @@ extern "C"{
 #endif
 
 const DioConfig_t * const DIO_configGet(void);
+size_t DIO_configSizeGet(void);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/SPI_Master/include/spi.h
+++ b/SPI_Master/include/spi.h
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
 #include <assert.h>
 #include "spi_cfg.h"
 #include "stm32f4xx.h"   

--- a/SPI_Master/include/spi.h
+++ b/SPI_Master/include/spi.h
@@ -1,13 +1,13 @@
 /**
  * @file spi.h
  * @author Jose Luis Figueroa 
- * @brief The interface definition for the spi. This is the header file for 
+ * @brief The interface definition for the SPI. This is the header file for 
  * the definition of the interface for a Serial Peripheral Serial (SPI) on 
  * a standard microcontroller.
- * @version 1.0
- * @date 2023-07-14
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. All rights reserved.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. All rights reserved.
  * 
  */
 #ifndef SPI_H_
@@ -18,6 +18,7 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+#include <assert.h>
 #include "spi_cfg.h"
 #include "stm32f4xx.h"   
 
@@ -36,6 +37,12 @@
 /*****************************************************************************
 * Typedefs
 *****************************************************************************/
+typedef struct
+{
+    SpiChannel_t Channel;           /**< The SPI channel */
+    uint16_t size;                  /**< The size of the data */
+    uint16_t *data;                 /**< The data to be sent */
+}SpiTransferConfig_t;
 
 /*****************************************************************************
 * Variables
@@ -48,9 +55,9 @@
 extern "C"{
 #endif
 
-void SPI_init(const SpiConfig_t * const Config);
-void SPI_transfer(SpiChannel_t Channel, uint16_t *data, uint16_t size);
-void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size);
+void SPI_init(const SpiConfig_t * const Config, size_t configSize);
+void SPI_transfer(const SpiTransferConfig_t * const TransferConfig);
+void SPI_receive(const SpiTransferConfig_t * const TransferConfig);
 void SPI_registerWrite(uint32_t address, uint32_t value);
 uint16_t SPI_registerRead(uint32_t address);
 

--- a/SPI_Master/include/spi_cfg.h
+++ b/SPI_Master/include/spi_cfg.h
@@ -2,39 +2,33 @@
  * @file spi_cfg.h
  * @author Jose Luis Figueroa 
  * @brief This module contains interface definitions for the SPI
- * configuration. This is the header file for the definition of the
- * interface for retrieving the Serial Peripheral interface
- * configuration table.
- * @version 1.0
- * @date 2023-07-14
+ * configuration. This is the header file for the definition of the interface
+ * for retrieving the Serial Peripheral interface configuration table.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef SPI_CFG_H_
 #define SPI_CFG_H_
 
-/**********************************************************************
+/*****************************************************************************
 * Includes
-**********************************************************************/
+*****************************************************************************/
+#include <stdio.h>
 
-/**********************************************************************
+/****************************************************************************
 * Preprocessor Constants
-**********************************************************************/
+*****************************************************************************/
 /** 
  * Defines the number of ports on the processor.
  */
 #define SPI_PORTS_NUMBER 4U
 
-/** 
- * Set the value according with the number of Serial Peripheral 
- * interface channels to be used.
-*/
-#define SPI_CHANNELS_NUMBER 1
-
-/**********************************************************************
+/****************************************************************************
 * Typedefs
-**********************************************************************/
+*****************************************************************************/
 /**
  * Define the SPI channels on the MCU device. It is used to specify
  * SPI channel to configure the register map.
@@ -44,7 +38,7 @@ typedef enum
     SPI_CHANNEL1,   /**< SPI Channel 1*/
     SPI_CHANNEL2,   /**< SPI Channel 2*/
     SPI_CHANNEL3,   /**< SPI Channel 3*/
-    SPI_CHANNEL4,    /**< SPI Channel 4*/
+    SPI_CHANNEL4,   /**< SPI Channel 4*/
     SPI_MAX_CHANNEL /**< Maximum SPI Channel*/
 }SpiChannel_t;
 
@@ -158,6 +152,7 @@ extern "C"{
 #endif
 
 const SpiConfig_t * const SPI_ConfigGet(void);
+size_t SPI_configSizeGet(void);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/SPI_Master/src/dio.c
+++ b/SPI_Master/src/dio.c
@@ -1,11 +1,11 @@
 /**
  * @file dio.c
  * @author Jose Luis Figueroa
- * @brief The implementation for the dio
- * @version 1.0
- * @date 2023-03-19
+ * @brief The implementation for the DIO driver.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 /*****************************************************************************
@@ -60,9 +60,7 @@ static uint32_t volatile * const pupdrRegister[NUMBER_OF_PORTS] =
     (uint32_t*)&GPIOH->PUPDR
 };
 
-/*
- * Defines a array of pointers to the GPIO port input data register.
-*/
+/* Defines a array of pointers to the GPIO port input data register. */
 static uint32_t volatile * const idrRegister[NUMBER_OF_PORTS] =  
 {
     (uint32_t*)&GPIOA->IDR, (uint32_t*)&GPIOB->IDR, (uint32_t*)&GPIOC->IDR,
@@ -97,27 +95,33 @@ static uint32_t volatile * const afrRegister[NUMBER_OF_PORTS] =
  * Function: DIO_init()
 *//**
 *\b Description:
- * This function is used to initialize the Dio based on the configuration  
+ * This function is used to initialize the DIO based on the configuration  
  * table defined in dio_cfg module.
  * 
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
- * PRE-CONDITION: NUMBER_OF_PORTS > 0 <br>
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
  * PRE-CONDITION: Configuration table needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: NUMBER_OF_PORTS > 0 <br>
+ * PRE-CONDITION: The setting is within the maximum values (DIO_MAX). <br>
  * 
  * POST-CONDITION: The DIO peripheral is set up with the configuration 
  * settings.
  * 
  * @param[in]   Config is a pointer to the configuration table that contains 
  *               the initialization for the peripheral.
+ * @param[in]   configSize is the size of the configuration table.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  const DioConfig_t * const DioConfig = DIO_configGet();
- *  DIO_init(DioConfig);
+ * const Dio_ConfigType_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * DIO_Init(DioConfig, configSize);
  * @endcode
  * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -126,11 +130,18 @@ static uint32_t volatile * const afrRegister[NUMBER_OF_PORTS] =
  * @see DIO_registerRead
  * 
 *****************************************************************************/
-void DIO_init(const DioConfig_t * const Config)
+void DIO_init(const DioConfig_t * const Config, size_t configSize)
 {
     /* Loop through all the elements of the configuration table. */
-    for(uint8_t i=0; i<NUMBER_DIGITAL_PINS; i++)
+    for(uint8_t i=0; i<configSize; i++)
     {
+        /* Prevent to assign a value out of the range of the port and pin.
+         * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+         * value can cause a memory violation.
+        */
+        assert(Config[i].Port < DIO_MAX_PORT);
+        assert(Config[i].Pin < DIO_MAX_PIN);
+
         /* 
          * Set the mode of the Dio pin on the GPIO port mode register. 
          * Multiply the pin number (Config[i].Pin) by two as MODER uses two 
@@ -159,7 +170,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            printf("This Mode does not exist\n");
+            assert(Config[i].Mode < DIO_MAX_MODE);
         }
 
         /*
@@ -176,7 +187,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            printf("This output type does not exist\n");
+            assert(Config[i].Type < DIO_MAX_TYPE);
         }
 
         /*
@@ -206,7 +217,7 @@ void DIO_init(const DioConfig_t * const Config)
         }
         else
         {
-            printf("The output speed does not exist\n");
+            assert(Config[i].Speed < DIO_MAX_SPEED);
         }
 
         /*
@@ -232,7 +243,7 @@ void DIO_init(const DioConfig_t * const Config)
        }
        else
        {
-            printf("The port register does not exist");
+            assert(Config[i].Resistor < DIO_MAX_RESISTOR);
        }
 
         /*
@@ -351,7 +362,11 @@ void DIO_init(const DioConfig_t * const Config)
             *afrRegister[Config[i].Port] |= (2UL<<(Config[i].Pin*4));
             *afrRegister[Config[i].Port] |= (4UL<<(Config[i].Pin*4));
             *afrRegister[Config[i].Port] |= (8UL<<(Config[i].Pin*4));
-       } 
+       }
+       else
+       {
+            assert(Config[i].Function < DIO_MAX_FUNCTION);
+       }
 
     }
 }
@@ -360,25 +375,36 @@ void DIO_init(const DioConfig_t * const Config)
  * Function: DIO_pinRead()
 *//**
  *\b Description:
- * This function is used to read the state of a dio pin.
+ * This function is used to reads the state of a specified pin.
+ * This function reads the state of a digital input/output pin specified by
+ * the DioPinConfig_t structure, which contains the port and pin information.
  * 
  * PRE-CONDITION: The pin is configured as INPUT <br>
  * PRE-CONDITION: The pin is configured as GPIO <br>
- * PRE-CONDITION: The Port is within the maximum DioPort_t.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
  * PRE-CONDITION: The Pin is within the maximum DioPin_t. 
- * definition.
+ * definition. <br>
  * 
- * POST-CONDITION: The channel state is returned.
+ * POST-CONDITION: The channel state is returned. <br>
  * 
- * @param[in]   Port is the DioPort_t that represents a port.
- * @param[in]   Pin is the DioPin_t that represents a pin.
- * @return      The state of the channel as HIGH or LOW.
+ * @param[in] PinConfig A pointer to a structure containing the port and pin 
+ * to be read.
+ * 
+ * @return    DioPinState_t The state of the pin (high or low).
  * 
  * \b Example:
  * @code
- *  bool pin = DIO_pinRead(DIO_PC, DIO_PC5);
+ * const DioPinConfig_t  UserButton1= 
+ * {
+ *      .Port = DIO_PC, 
+ *      .Pin = DIO_PC13
+ * };
+ *  bool pin = DIO_pinRead(&UserButton1);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -387,12 +413,19 @@ void DIO_init(const DioConfig_t * const Config)
  * @see DIO_registerRead
  * 
 **********************************************************************/
-DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
+DioPinState_t DIO_pinRead(const DioPinConfig_t * const PinConfig)
 {
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
     /* Read the port associated with the desired pin */
-    uint16_t portState = *idrRegister[Port];
+    uint16_t portState = *idrRegister[PinConfig->Port];
     /* Determinate the Port bit associated with this pin*/
-    uint16_t pinMask = (1UL<<(Pin));
+    uint16_t pinMask = (1UL<<(PinConfig->Pin));
 
     return ((portState & pinMask) ? DIO_HIGH : DIO_LOW); 
 }
@@ -402,31 +435,45 @@ DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
 *//**
  *\b Description:
  * This function is used to write the state of a pin as either logic 
- * high or low through the use of the DioChannel_t enum to select the 
- * channel and the DioPinState_t to define the desired state.
+ * high or low. it reads the state of a digital input/output pin 
+ * specified by the DioPinConfig_t structure and the DioPinState_t to 
+ * define the desired state, which contains the port and pin 
+ * information.
  * 
  * PRE-CONDITION: The pin is configured as OUTPUT <br>
  * PRE-CONDITION: The pin is configured as GPIO <br>
- * PRE-CONDITION: The pin is within the maximum DioChannel_t .
- * definition.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
+ * PRE-CONDITION: The Pin is within the maximum DioPin_t. <br>
+ * PRE-CONDITION: The State is within the maximum DioPinState_t. <br>
  * 
- * POST-CONDITION: The channel state will be Stated.
+ * POST-CONDITION: The channel state is Stated. <br>
  * 
- * @param[in]   Port is the GPIO to write using the DioPort_t enum.
- * @param[in]   Pin is the bit to write using the DioPin_t enum 
- *              definition.
+ * @param[in]   pinConfig A pointer to a structure containing the port 
+ *              and pin to be written.
  * @param[in]   State is HIGH or LOW as defined in the DioPinState_t 
  *              enum. 
- *          
  * 
- * @return  void
+ * @return      void
  * 
  * \b Example:
  * @code
- *  DIO_pinWrite(DIO_PA, DIO_PA1, LOW);  //Set the PORT pin low
- *  DIO_pinWrite(DIO_PB, DIO_PB3, HIGH); //Set the PORT pin high
+ * const DioPinConfig_t  UserLED1= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA5
+ * };
+ * const DioPinConfig_t  UserLED2= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA6
+ * };
+ * DIO_pinWrite(&UserLED1, LOW);    //Set the pin low
+ * DIO_pinWrite(&UserLED2, HIGH);   //Set the pin high
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -435,19 +482,26 @@ DioPinState_t DIO_pinRead(DioPort_t Port, DioPin_t Pin)
  * @see DIO_registerRead
  * 
  **********************************************************************/
-void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
+void DIO_pinWrite(const DioPinConfig_t * const PinConfig, DioPinState_t State)
 {
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
     if(State == DIO_HIGH)
     {
-        *odrRegister[Port] |= (1UL<<(Pin));
+        *odrRegister[PinConfig->Port] |= (1UL<<(PinConfig->Pin));
     }
     else if (State == DIO_LOW)
     {
-        *odrRegister[Port] &= ~(1UL<<Pin);
+        *odrRegister[PinConfig->Port] &= ~(1UL<<(PinConfig->Pin));
     }
     else
     {
-        printf("This option does not exist");
+        assert(State < DIO_PIN_STATE_MAX);
     }
 }
 
@@ -455,25 +509,36 @@ void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
  * Function: DIO_pinToggle()
 *//**
  *\b Description:
- * This function is used to toggle the current state of a pin.
+ * This function is used to toggle the current state of a pin. 
+ * This function reads the state of a digital input/output pin 
+ * specified by the DioPinConfig_t structure, which contains the port 
+ * and pin information.
  * 
  * PRE-CONDITION: The channel is configured as output <br>
  * PRE-CONDITION: The channel is configured as GPIO <br>
- * PRE-CONDITION: The channel is within the maximum DioChannel_t 
- * definition.
+ * PRE-CONDITION: DioPinConfig_t needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The Port is within the maximum DioPort_t. <br>
+ * PRE-CONDITION: The Pin is within the maximum DioPin_t. <br>
  *
- * POST-CONDITION:
+ * POST-CONDITION: The channel state is toggled. <br>
  * 
- * @param[in]   Port is the GPIO to write using the DioPort_t enum.
- * @param[in]   Pin is the bit from the DioPin_t that is to be modified
+ * @param[in]   pinConfig A pointer to a structure containing the port 
+ *              and pin to be toggled.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  DIO_pinToggle(DIO_PA, DIO_PA3);
+ * const DioPinConfig_t  UserLED1= 
+ * {
+ *      .Port = DIO_PA, 
+ *      .Pin = DIO_PA5
+ * };
+ * DIO_pinToggle(&UserLED1);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_pinRead
  * @see DIO_pinWrite
@@ -482,29 +547,36 @@ void DIO_pinWrite(DioPort_t Port, DioPin_t Pin, DioPinState_t State)
  * @see DIO_registerRead
  * 
  **********************************************************************/
-void DIO_pinToggle(DioPort_t Port, DioPin_t Pin)
+void DIO_pinToggle(const DioPinConfig_t * const PinConfig)
 {
-    *odrRegister[Port] ^= (1UL<<Pin);
+    /* Prevent to assign a value out of the range of the port and pin.
+     * The registers arrays are limited to the NUMBER_OF_PORTS, higher 
+     * value can cause a memory violation.
+    */
+    assert(PinConfig->Port < DIO_MAX_PORT);
+    assert(PinConfig->Pin < DIO_MAX_PIN);
+
+    *odrRegister[PinConfig->Port] ^= (1UL<<(PinConfig->Pin));
 }
 
 /**********************************************************************
  * Function: DIO_registerWrite()
 *//**
  *\b Description:
- * This function is used to directly address and modify a Dio register.
+ * This function is used to directly address and modify a GPIO register.
  * The function should be used to access specialized functionality in 
- * the Dio peripheral that is not exposed by any other function of the
+ * the DIO peripheral that is not exposed by any other function of the
  * interface.
  * 
- * PRE-CONDITION: Address is within the boundaries of the Dio register
- * address space.
+ * PRE-CONDITION: Address is within the boundaries of the DIO register
+ * address space. <br>
  * 
  * POST-CONDITION: The register located at address with be updated with
- * value.
+ * value. <br>
  * 
- * @param[in]   address is a register address within the Dio peripheral
+ * @param[in]   address is a register address within the DIO peripheral
  *              map.
- * @param[in]   value is the value to set the Dio register. 
+ * @param[in]   value is the value to set the DIO register. 
  * 
  * @return void
  * 
@@ -513,10 +585,12 @@ void DIO_pinToggle(DioPort_t Port, DioPin_t Pin)
  *  DIO_registerWrite(0x1000, 0x15);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
- * @see DIO_channelRead
- * @see DIO_channelWrite
- * @see DIO_channelToggle
+ * @see DIO_pinRead
+ * @see DIO_pinWrite
+ * @see DIO_pinToggle
  * @see DIO_registerWrite
  * @see DIO_registerRead
  * 
@@ -537,10 +611,10 @@ void DIO_registerWrite(uint32_t address, uint32_t value)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the Dio register 
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The value stored in the register is returned to the 
- * caller.
+ * caller. <br>
  * 
  * @param[in]   address is the address of the Dio register to read.
  * 
@@ -551,10 +625,12 @@ void DIO_registerWrite(uint32_t address, uint32_t value)
  * type dioValue = DIO_registerRead(0x1000);
  * @endcode
  * 
+ * @see DIO_ConfigGet
+ * @see DIO_configSizeGet
  * @see DIO_init
- * @see DIO_channelRead
- * @see DIO_channelWrite
- * @see DIO_channelToggle
+ * @see DIO_pinRead
+ * @see DIO_pinWrite
+ * @see DIO_pinToggle
  * @see DIO_registerWrite
  * @see DIO_registerRead
  *

--- a/SPI_Master/src/dio_cfg.c
+++ b/SPI_Master/src/dio_cfg.c
@@ -3,10 +3,10 @@
  * @author Jose Luis Figueroa
  * @brief This module contains the implementation for the digital 
  * input/output peripheral configuration.
- * @version 1.0
- * @date 2023-03-17
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 
@@ -35,14 +35,15 @@
  * input/output peripheral channel (pin). Each row represent a single pin.
  * Each column is representing a member of the DioConfig_t structure. This 
  * table is read in by Dio_Init, where each channel is then set up based on 
- * this table.
+ * this table. The NUMBER_DIGITAL_PINS constant should be accorded with the
+ * number of rows.
 */
 const DioConfig_t DioConfig[] = 
 {
 /*                                                          
  *  Port    Pin      Mode        Type           Speed          Resistor         Function
  *                
-*/ 
+*/
    {DIO_PA, DIO_PA4, DIO_OUTPUT,   DIO_PUSH_PULL, DIO_LOW_SPEED, DIO_NO_RESISTOR, DIO_AF5},
    {DIO_PA, DIO_PA5, DIO_FUNCTION, DIO_PUSH_PULL, DIO_LOW_SPEED, DIO_NO_RESISTOR, DIO_AF5},
    {DIO_PA, DIO_PA6, DIO_FUNCTION, DIO_PUSH_PULL, DIO_LOW_SPEED, DIO_NO_RESISTOR, DIO_AF5},
@@ -64,18 +65,23 @@ const DioConfig_t DioConfig[] =
  * This function is used to initialize the DIO based on the configuration
  * table defined in dio_cfg module.
  * 
- * PRE-CONDITION: configuration table needs to be populated (sizeof > 0)
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
  * POST-CONDITION: A constant pointer to the first member of the  
- * configuration table will be returned.
- * @return A pointer to the configuration table.
+ * configuration table will be returned.<br>
+ * 
+ * @return A pointer to the configuration table. <br>
  * 
  * \b Example: 
  * @code
- * const Dio_ConfigType_t * const DioConfig = DIO_configGet();
+ * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
  * 
- * DIO_Init(DioConfig);
+ * DIO_Init(DioConfig, configSize);
  * @endcode
  * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
  * @see DIO_init
  * @see DIO_channelRead
  * @see DIO_channelWrite
@@ -92,4 +98,40 @@ const DioConfig_t * const DIO_configGet(void)
    */
   return (const DioConfig_t*)&DioConfig[0];
 
+}
+
+/*****************************************************************************
+ * Function: DIO_getConfigSize()
+*/
+/**
+*\b Description:
+ * This function is used to get the size of the configuration table.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
+ * POST-CONDITION: The size of the configuration table will be returned. <br>
+ * 
+ * @return The size of the configuration table.
+ * 
+ * \b Example: 
+ * @code
+ * const Dio_Config_t * const DioConfig = DIO_configGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * DIO_Init(DioConfig, configSize);
+ * @endcode
+ * 
+ * @see DIO_configGet
+ * @see DIO_configSizeGet
+ * @see DIO_init
+ * @see DIO_channelRead
+ * @see DIO_channelWrite
+ * @see DIO_channelToggle
+ * @see DIO_registerWrite
+ * @see DIO_registerRead
+ * 
+*****************************************************************************/
+size_t DIO_configSizeGet(void)
+{
+   return sizeof(DioConfig)/sizeof(DioConfig[0]);
 }

--- a/SPI_Master/src/spi.c
+++ b/SPI_Master/src/spi.c
@@ -1,11 +1,11 @@
 /**
  * @file spi.c
  * @author Jose Luis Figueroa 
- * @brief The implementation for the SPI.
- * @version 1.0
- * @date 2023-07-14
+ * @brief The implementation for the SPI Driver.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 /*****************************************************************************
@@ -67,27 +67,32 @@ static uint16_t volatile * const dataRegister[SPI_PORTS_NUMBER] =
  * Function: SPI_init()
 *//**
 *\b Description:
- * This function is used to initialize the spi based on the configuration  
+ * This function is used to initialize the SPI based on the configuration  
  * table defined in spi_cfg module.
  * 
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
- * PRE-CONDITION: SPI pins should be configured using GPIO driver.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI pins should be configured using GPIO driver. <br>
  * PRE-CONDITION: Configuration table needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The setting is within the maximum values (SPI_MAX). <br>
  *
- * POST-CONDITION: The peripheral is set up with the configuration settings.
+ * POST-CONDITION: The peripheral is set up with the configuration settings. <br>
  * 
  * @param[in]   Config is a pointer to the configuration table that contains 
- *               the initialization for the peripheral.
+ *               the initialization for the peripheral. 
+ * @param[in]   configSize is the size of the configuration table. 
  * 
- * @return  void
- * 
+ * @return  void 
+ *  
  * \b Example:
  * @code
  *  const SpiConfig_t * const SpiConfig = SPI_configGet();
- *  SPI_Init(DioConfig);
+ *  size_t configSize = SPI_configSizeGet();
+ * 
+ *  SPI_Init(DioConfig, configSize);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_getConfigSize
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
@@ -95,11 +100,17 @@ static uint16_t volatile * const dataRegister[SPI_PORTS_NUMBER] =
  * @see SPI_CallbackRegister
  * 
 *****************************************************************************/
-void SPI_init(const SpiConfig_t * const Config)
+void SPI_init(const SpiConfig_t * const Config, size_t configSize)
 {
     /**Loop through all the elements of the configuration table.*/
-    for(uint8_t i=0; i<SPI_CHANNELS_NUMBER; i++)
+    for(uint8_t i=0; i<configSize; i++)
     {
+        /* Prevent to assign a value out of the range of the channels.
+         * The registers arrays are limited to the SPI_PORTS_NUMBER, higher 
+         * value can cause a memory violation.
+        */
+       assert(Config[i].Channel < SPI_MAX_CHANNEL);
+
         /**Set the configuration of the SPI on the control register 1*/
         /**Set the Clock phase and polarity modes*/
         if(Config[i].Mode == SPI_MODE0)
@@ -124,7 +135,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This mode does not exist\n");
+            assert(Config[i].Mode < SPI_MAX_MODE);
         }
 
         /**Set the hierarchy of the device*/
@@ -138,7 +149,7 @@ void SPI_init(const SpiConfig_t * const Config)
         } 
         else
         {
-            printf("This hierarchy does not exist\n");
+            assert(Config[i].Hierarchy < SPI_MAX_HIERARCHY);
         }
 
         /**Set the baud rate of the device*/
@@ -192,7 +203,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This baud rate does not exist\n");
+            assert(Config[i].BaudRate < SPI_MAX_FPCLK);
         }
 
         /**Set the slave select pin management for the device*/
@@ -213,7 +224,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This slave select pin option does not exist\n");
+            assert(Config[i].SlaveSelect < SPI_MAX_NSS);
         }
 
         /**Set the frame format of the device*/
@@ -227,7 +238,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This frame format does not exist\n");
+            assert(Config[i].FrameFormat < SPI_MAX_FF);
         }
 
         /**Set the data transfer type of the device*/
@@ -241,7 +252,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This data transfer type does not exist");
+            assert(Config[i].TypeTransfer < SPI_MAX_DF);
         }
 
         /**Set the data frame format (size) of the device*/
@@ -255,7 +266,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This data size does not exist\n");
+            assert(Config[i].DataSize < SPI_MAX_BITS);
         }
 
         /**Enable the SPI module*/
@@ -264,114 +275,153 @@ void SPI_init(const SpiConfig_t * const Config)
 
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_Transfer()
 *//**
  *\b Description:
- * This function is used to initialize a data transfer on the SPI bus. 
+ * This function is used to initialize a data transfer on the SPI bus. This 
+ * function is used to send data to a slave device specified by the 
+ * SpiTransferConfig_t structure, which contains the channel, size, and data.
  * 
- * PRE-CONDITION: SPI_Init must be called with valid configuration data.
- * PRE-CONDITION: SpiTransfer_t needs to be populated.
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI_Init must be called with valid configuration data. <br>
+ * PRE-CONDITION: SpiTransferConfig_t needs to be populated. <br>
+ * PRE-CONDITION: The Channel is within the maximum SpiChannel_t. <br>
+ * PRE-CONDITION: The size is greater than 0. <br>
+ * PRE-CONDITION: The data is not NULL. <br>
  * 
- * POST-CONDITION: Data transferred based on configuration.
+ * POST-CONDITION: Data transferred based on configuration. <br>
  * 
- * @param[in]   data(pointer) is the information to be sent.
- * @param[in]   size is data size.
+ * @param[in] SpiTransferConfig A pointer to a structure containing the
+ * channel, size, and data to be read.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  SPI_Transfer(*data, size);
+ * uint16_t data[] = {0x56};
+ * SpiTransferConfig_t TransferConfig =
+ * {
+ *     .Channel = SPI_CHANNEL1,
+ *     .size = sizeof(data)/sizeof(data[0]),
+ *     .data = data
+ * };
+ * SPI_Transfer(&TransferConfig);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_getConfigSize
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  * 
- **********************************************************************/
-void SPI_transfer(SpiChannel_t Channel, uint16_t *data, uint16_t size)
+ ****************************************************************************/
+void SPI_transfer(const SpiTransferConfig_t * const TransferConfig)
 {
-    for(uint16_t i=0; i<size; i++)
+    /* Prevent to assign a value out of the range of the channel*/
+    assert(TransferConfig->Channel < SPI_MAX_CHANNEL);
+    /* Prevent to use an empty data size*/
+    assert(TransferConfig->size > 0);
+    /* Prevent to use an empty data transfer*/
+    assert(TransferConfig->data != NULL);
+
+    for (uint16_t i = 0; i < TransferConfig->size; i++)
     {
         /* Wait until TXE is set (buffer empty)*/
-        while(!(*statusRegister[Channel] & SPI_SR_TXE))
+        while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_TXE))
         {
             asm("nop");
         }
-        *dataRegister[Channel] = data[i];
+        *dataRegister[TransferConfig->Channel] = TransferConfig->data[i];
     }
 
     /* Wait until TXE is set to ensure the bus is empty*/
-    while(!(*statusRegister[Channel] & SPI_SR_TXE))
+    while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_TXE))
     {
         asm("nop");
     }
 
     /* Wait until bus is not busy to reset*/
-    while(*statusRegister[Channel] & SPI_SR_BSY)
+    while(*statusRegister[TransferConfig->Channel] & SPI_SR_BSY)
     {
         asm("nop");
     }
 
     /* Clear OVR bit (Overrun flag) in case of error*/
     uint16_t clearingFlag;
-    clearingFlag = *dataRegister[Channel];
-    clearingFlag = *statusRegister[Channel];
+    clearingFlag = *dataRegister[TransferConfig->Channel];
+    clearingFlag = *statusRegister[TransferConfig->Channel];
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_Receive()
 *//**
  *\b Description:
- * This function is used to initialize a data reception on the SPI bus. 
+ * This function is used to initialize a data reception on the SPI bus. This 
+ * function is used to receive data specified by the  SpiTransferConfig_t 
+ * structure, which contains the channel, size, and data.
  * 
- * PRE-CONDITION: SPI_Init must be called with valid configuration data.
- * PRE-CONDITION: SpiTransfer_t needs to be populated.
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI_Init must be called with valid configuration data. <br>
+ * PRE-CONDITION: SpiTransferConfig_t needs to be populated. <br>
+ * PRE-CONDITION: The Channel is within the maximum SpiChannel_t. <br>
+ * PRE-CONDITION: The size is greater than 0. <br>
+ * PRE-CONDITION: The data is not NULL. <br>
  * 
  * POST-CONDITION: Data transferred based on configuration.
  * 
- * @param[in]   data(pointer) is the information to be sent.
- * @param[in]   size is data size.
+ * @param[in] SpiTransferConfig A pointer to a structure containing the 
+ * channel, size, and data to be read.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  SPI_Receive(*data, size);
+* uint16_t rxdata[1];
+ * SpiTransferConfig_t ReceiveConfig =
+ * {
+ *     .Channel = SPI_CHANNEL1,
+ *     .size = sizeof(rxdata)/sizeof(rxdata[0]),
+ *     .data = rxdata
+ * };
+ * SPI_receive(&ReceiveConfig);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_getConfigSize
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  * 
- **********************************************************************/
-void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
+ ****************************************************************************/
+void SPI_receive(const SpiTransferConfig_t * const TransferConfig)
 {
-    while(size)
+    /* Prevent to assign a value out of the range of the channel*/
+    assert(TransferConfig->Channel < SPI_MAX_CHANNEL);
+    /* Prevent to use an empty data size*/
+    assert(TransferConfig->size > 0);
+    /* Prevent to use an empty data transfer*/
+    assert(TransferConfig != NULL);
+
+    for (uint8_t i = 0; i < TransferConfig->size; i++)
     {
         /* Send dummy data (Recommended).*/
-        *dataRegister[Channel] = 0;
+        *dataRegister[TransferConfig->Channel] = 0;
         /* Wait for RXEN flag to be sent*/
-        while(!(*statusRegister[Channel] & SPI_SR_RXNE))
+        while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_RXNE))
         {
             asm("nop");
         }
         /* Read the data*/
-        *data = *dataRegister[Channel];
-        size--;
+        TransferConfig->data[i] = *dataRegister[TransferConfig->Channel];
     }
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_registerWrite()
 *//**
  *\b Description:
@@ -381,10 +431,10 @@ void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the SPI register
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The register located at address with be updated with
- * value.
+ * value. <br>
  * 
  * @param[in]   address is a register address within the SPI peripheral
  *              map.
@@ -397,21 +447,22 @@ void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
  *  SPI_registerWrite(0x1000, 0x15);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  * 
-**********************************************************************/  
+****************************************************************************/  
 void SPI_registerWrite(uint32_t address, uint32_t value)
 {
     volatile uint32_t * const registerPointer = (uint32_t*)address;
     *registerPointer = value;
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_registerRead()
 *//**
  *\b Description:
@@ -421,10 +472,10 @@ void SPI_registerWrite(uint32_t address, uint32_t value)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the SPI register 
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The value stored in the register is returned to the 
- * caller.
+ * caller. <br>
  * 
  * @param[in]   address is the address of the SPI register to read.
  * 
@@ -435,14 +486,15 @@ void SPI_registerWrite(uint32_t address, uint32_t value)
  * type spiValue = SPI_registerRead(0x1000);
  * @endcode
  * 
- * @see SPI_ConfigGet
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
  * @see SPI_RegisterRead
  * @see SPI_CallbackRegister
  *
- **********************************************************************/
+ ****************************************************************************/
 uint16_t SPI_registerRead(uint32_t address)
 {
     volatile uint16_t * const registerPointer = (uint16_t *)address;

--- a/SPI_Master/src/spi_cfg.c
+++ b/SPI_Master/src/spi_cfg.c
@@ -3,10 +3,10 @@
  * @author Jose Luis Figueroa.
  * @brief This module contains the implementation for the Serial Peripheral
  * Interface (SPI).
- * @version 1.0
- * @date 2023-07-14
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 
@@ -63,19 +63,22 @@ const SpiConfig_t SpiConfig[] =
  * This function is used to initialize the SPI based on the configuration
  * table defined in spi_cfg module.
  * 
- * PRE-CONDITION: configuration table needs to be populated (sizeof > 0)
- * POST-CONDITION: A constant pointer to the first member of the  
- * configuration table will be returned.
- * @return A pointer to the configuration table.
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0). <br>
+ * POST-CONDITION: A constant pointer to the first member of the configuration 
+ * table will be returned. <br>
+ * 
+ * @return A pointer to the configuration table. <br>
  * 
  * \b Example: 
  * @code
  * const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * size_t configSize = DIO_configSizeGet();
  * 
- * SPI_Init(SpiConfig);
+ * SPI_Init(SpiConfig, configSize);
  * @endcode
- * 
- * @see SPI_ConfigGet
+ *
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
@@ -91,4 +94,39 @@ const SpiConfig_t * const SPI_ConfigGet(void)
    */
   return (const SpiConfig_t*)&SpiConfig[0];
 
+}
+
+/*****************************************************************************
+ * Function: SPI_configSizeGet()
+*/
+/**
+*\b Description:
+ * This function is used to get the size of the configuration table.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
+ * POST-CONDITION: The size of the configuration table will be returned. <br>
+ * 
+ * @return The size of the configuration table. <br>
+ * 
+ * \b Example: 
+ * @code
+ * const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * SPI_Init(SpiConfig, configSize);
+ * @endcode
+ * 
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ * 
+*****************************************************************************/
+size_t SPI_configSizeGet(void)
+{
+   return sizeof(SpiConfig)/sizeof(SpiConfig[0]);
 }


### PR DESCRIPTION
The assert macro implementation is added to catch bux on the development stage.

The DIO_configSizeGet and SPI_configSizeGet functions were added to get the table size automatically.

Modified function arguments to pass structures by pointer (DioPinConfig_t and SpiTransferConfig_t ) instead of by value. This reduces memory overhead and allows direct modification of struct members without unnecessary copies and a defensive programming approach.

The main codes were updated to communicate through SPI protocol between the master and slave.

Comments were updated according to new updates.